### PR TITLE
fix: application source path

### DIFF
--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -14,7 +14,7 @@ jobs:
       source-repo: litmuschaos/litmus
       # litmuschaos is a monorepo, so we'll need a custom script to update the golang version
       update-script: |
-        go_version="$(grep -Po "^go \K(\S+)" "$GITHUB_WORKSPACE/application_src/chaoscenter/authentication/go.mod")" \
+        go_version="$(grep -Po "^go \K(\S+)" "$GITHUB_WORKSPACE/application-src/chaoscenter/authentication/go.mod")" \
         # Delete the Go dependency and add the updated one
         yq -i 'del(.parts.litmuschaos-authserver.build-snaps.[] | select(. == "go/*"))' \
         "$rockcraft_yaml"


### PR DESCRIPTION
~## Issue~
~1- The shared CI doesn't clone the application source repo~
~2- In the shared wf, https://github.com/canonical/observability/blob/main/.github/workflows/rock-update.yaml#L164, we use an unquoted heredoc (`EOF`), which will expand the vars and evaluate expressions before dumping the content in the script. So, for example, it will try to evaluate the `grep` command to fetch the `go.mod` version before even cloning the repo.~

~## Solution~
~1- clone the application source repo first~
~2- Escape all `$` chars~

Should be `application-src` instead of `application_src`
