### PR TITLE
fix: Fixes setting build-snaps in the rock-update workflow

### DIFF
--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -14,13 +14,13 @@ jobs:
       source-repo: litmuschaos/litmus
       # litmuschaos is a monorepo, so we'll need a custom script to update the golang version
       update-script: |
-        go_version="$(grep -Po "^go \K(\S+)" "$GITHUB_WORKSPACE/application-src/chaoscenter/authentication/go.mod")"
+        go_version="\$(grep -Po "^go \K(\S+)" "$GITHUB_WORKSPACE/application-src/chaoscenter/authentication/go.mod")"
         # Delete the Go dependency and add the updated one
         yq -i 'del(.parts.litmuschaos-authserver.build-snaps.[] | select(. == "go/*"))' \
         "$rockcraft_yaml"
         # Snap channels are named after major.minor only, so cut the go version to that format
-        go_major_minor="$(echo "$go_version" | sed -E "s/([0-9]+\.[0-9]+).*/\1/")"
-        go_v="$go_major_minor" yq -i \
+        go_major_minor="\$(echo "\$go_version" | sed -E "s/([0-9]+\.[0-9]+).*/\1/")"
+        go_v="\$go_major_minor" yq -i \
         '.parts.litmuschaos-authserver.build-snaps += "go/"+strenv(go_v)+"/stable"' \
         "$rockcraft_yaml"
       check-go: false

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -14,6 +14,8 @@ jobs:
       source-repo: litmuschaos/litmus
       # litmuschaos is a monorepo, so we'll need a custom script to update the golang version
       update-script: |
+        # When editing the script, make sure to escape all dollar signs to prevent variables from being evaluated
+        # at the time of saving the script to a file, unless this is the desired behavior. 
         go_version="\$(grep -Po "^go \K(\S+)" "$GITHUB_WORKSPACE/application-src/chaoscenter/authentication/go.mod")"
         # Delete the Go dependency and add the updated one
         yq -i 'del(.parts.litmuschaos-authserver.build-snaps.[] | select(. == "go/*"))' \


### PR DESCRIPTION
## Issue
https://github.com/canonical/litmuschaos-authserver-rock/issues/14

## Context
The `update-script` from the `rock-update` workflow is passed to and processed by the shared workflow. The shared workflow saves the script to a file. When this happens, all variables in the script are being evaluated. The problem is that the script is not processed line-by-line but as a whole. As a result only the first variable (`go_version`) is evaluated correctly. Other variables, which depend on `go_version`, become empty strings.

## Solution
Escaping variables in the `update-script` prevents evaluation at the time of writing the script to the file. Variables will be correctly evaluated at run time.

NOTE:
Once this fix is merged, #15 should be closed and the `rock-update` workflow should be triggered again (manually or by the scheduler).


