### PR TITLE
chore: use auth as pebble service name

### DIFF
--- a/3.20.0/rockcraft.yaml
+++ b/3.20.0/rockcraft.yaml
@@ -7,7 +7,7 @@ version: "3.20.0"
 base: ubuntu@24.04
 license: Apache-2.0
 services:
-  authserver:
+  auth:
     command: bin/server
     override: replace
     startup: enabled


### PR DESCRIPTION
Contributes to fixing #https://github.com/canonical/litmus-operators/issues/19